### PR TITLE
make python3.4 compatible. add subdomains support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ using [Certbot](https://certbot.eff.org/) DNS-01 challenge validation for domain
 
 ## Setup
 
-The scripts use the [untangle](https://untangle.readthedocs.io/en/latest/) library, if not already installed on your system:
+The scripts use the [untangle](https://untangle.readthedocs.io/en/latest/) and tldextract libraries, if not already installed on your system:
 
 ```
 pip install untangle
+
+pip install tldextract
 ```
 
 Download the [latest release](https://github.com/ethauvin/namesilo-letsencrypt/releases) archive and expand it in the desired directory.
@@ -44,3 +46,4 @@ certbot certonly --manual --email you@example.com \
 </pre>
 
 Please note that NameSilo DNS propagation takes up to **15 minutes**. The scripts will wait **20 minutes** before completing, just to be safe.
+q

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NameSilo Let's Encrypt
 
 [![License (3-Clause BSD)](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](http://opensource.org/licenses/BSD-3-Clause)
-[![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/)
+[![Python 3.4](https://img.shields.io/badge/python-3.4-blue.svg)](https://www.python.org/)
 
 Python scripts (hook) to automate obtaining [Let's Encrypt](https://letsencrypt.org/) certificates,
 using [Certbot](https://certbot.eff.org/) DNS-01 challenge validation for domains DNS hosted on

--- a/authenticator.py
+++ b/authenticator.py
@@ -37,6 +37,7 @@ import tempfile
 import time
 import urllib.request
 
+import tldextract
 import untangle
 
 from config import apikey, wait
@@ -52,14 +53,20 @@ def sleep(minutes):
 domain = os.environ['CERTBOT_DOMAIN']
 validation = os.environ['CERTBOT_VALIDATION']
 tmpdir = os.path.join(tempfile.gettempdir(), "CERTBOT_"+domain)
+rrhost = "_acme-challenge"
 
 if "NAMESILO_API" in os.environ:
     apikey = os.environ['NAMESILO_API']
 
 
+tld = tldextract.extract(domain)
+nsdomain = tld.domain+"."+tld.suffix
+if tld.subdomain:
+    rrhost += "."+tld.subdomain
+
 url = "https://www.namesilo.com/api/dnsAddRecord?\
-version=1&type=xml&key="+apikey+"&domain="+domain+"&rrtype=TXT\
-&rrhost=_acme-challenge&rrvalue="+validation+"&rrttl=3600"
+version=1&type=xml&key="+apikey+"&domain="+nsdomain+"&rrtype=TXT\
+&rrhost="+rrhost+"&rrvalue="+validation+"&rrttl=3600"
 
 req = urllib.request.Request(
     url,

--- a/authenticator.py
+++ b/authenticator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 
 #  authenticator.py
 #
@@ -51,14 +51,15 @@ def sleep(minutes):
 
 domain = os.environ['CERTBOT_DOMAIN']
 validation = os.environ['CERTBOT_VALIDATION']
-tmpdir = os.path.join(tempfile.gettempdir(), f"CERTBOT_{domain}")
+tmpdir = os.path.join(tempfile.gettempdir(), "CERTBOT_"+domain)
 
 if "NAMESILO_API" in os.environ:
     apikey = os.environ['NAMESILO_API']
 
-url = f"https://www.namesilo.com/api/dnsAddRecord?\
-version=1&type=xml&key={apikey}&domain={domain}&rrtype=TXT\
-&rrhost=_acme-challenge&rrvalue={validation}&rrttl=3600"
+
+url = "https://www.namesilo.com/api/dnsAddRecord?\
+version=1&type=xml&key="+apikey+"&domain="+domain+"&rrtype=TXT\
+&rrhost=_acme-challenge&rrvalue="+validation+"&rrttl=3600"
 
 req = urllib.request.Request(
     url,

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 
 #  cleanup.py
 #
@@ -41,13 +41,14 @@ import untangle
 from config import apikey
 
 domain = os.environ['CERTBOT_DOMAIN']
-tmpdir = os.path.join(tempfile.gettempdir(), f"CERTBOT_{domain}")
+tmpdir = os.path.join(tempfile.gettempdir(), "CERTBOT_"+domain)
+
 
 if "NAMESILO_API" in os.environ:
     apikey = os.environ['NAMESILO_API']
 
-url = f"https://www.namesilo.com/api/dnsDeleteRecord\
-?version=1&type=xml&key={apikey}&domain={domain}&rrid="
+url = "https://www.namesilo.com/api/dnsDeleteRecord\
+?version=1&type=xml&key="+apikey+"&domain="+domain+"&rrid="
 
 
 def getrequest(record_id):

--- a/cleanup.py
+++ b/cleanup.py
@@ -36,6 +36,7 @@ import sys
 import tempfile
 import urllib.request
 
+import tldextract
 import untangle
 
 from config import apikey
@@ -47,9 +48,11 @@ tmpdir = os.path.join(tempfile.gettempdir(), "CERTBOT_"+domain)
 if "NAMESILO_API" in os.environ:
     apikey = os.environ['NAMESILO_API']
 
-url = "https://www.namesilo.com/api/dnsDeleteRecord\
-?version=1&type=xml&key="+apikey+"&domain="+domain+"&rrid="
+tld = tldextract.extract(domain)
+nsdomain = tld.domain+"."+tld.suffix
 
+url = "https://www.namesilo.com/api/dnsDeleteRecord\
+?version=1&type=xml&key="+apikey+"&domain="+nsdomain+"&rrid="
 
 def getrequest(record_id):
     return urllib.request.Request(


### PR DESCRIPTION
python 3.4 still in use on many servers.

fix for subdomains, when e.g. "certbot -d subdomain.domain.com" used